### PR TITLE
dxf_viewer: Don't end pan on `PointerEvent::Leave`.

### DIFF
--- a/examples/dxf_viewer/src/main.rs
+++ b/examples/dxf_viewer/src/main.rs
@@ -345,7 +345,6 @@ impl ApplicationHandler for TabulonDxfViewer<'_> {
                                 pointer: PointerInfo { pointer_id, .. },
                                 ..
                             }
-                            | PointerEvent::Leave(PointerInfo { pointer_id, .. })
                             | PointerEvent::Cancel(PointerInfo { pointer_id, .. }) => {
                                 if viewer.gestures.pan == pointer_id {
                                     viewer.gestures.pan = None;


### PR DESCRIPTION
I introduced this issue when transitioning to ui-events.
`PointerEvent::Leave` is triggered even during pointer capture, so should not end a pan.