### PR TITLE
dxf_viewer: Use #[windows_subsystem = "windows"]

### DIFF
--- a/examples/dxf_viewer/src/main.rs
+++ b/examples/dxf_viewer/src/main.rs
@@ -4,6 +4,8 @@
 
 //! DXF viewer
 
+#![windows_subsystem = "windows"]
+
 use anyhow::Result;
 use joto_constants::u64::{INCH, MICROMETER};
 use std::num::NonZeroUsize;


### PR DESCRIPTION
This prevents the default console from showing, which fixes an issue where the main thread blocks on console output, which is very slow on Windows.